### PR TITLE
guides: deployment

### DIFF
--- a/content/docs/explanation/containers-architecture/_index.en.md
+++ b/content/docs/explanation/containers-architecture/_index.en.md
@@ -1,0 +1,30 @@
+---
+title: "Containers architecture"
+linkTitle: "Containers architecture"
+weight: 10
+description: "How the containers works together and how they are built"
+---
+
+There are 3 main containers deployed in a standard OSRD setup:
+ - **Gateway** _(includes the frontend)_: Serves the front end, handles authentication and proxies requests to the backend.
+ - **Editoast**: Acts as the backend that interacts with the front end.
+ - **Core**: Handles computation and business logic, called by Editoast.
+
+## Standard deployment
+
+The standard deployment can be represented with the following diagram.
+
+```mermaid
+flowchart TD
+    gw["gateway"]
+    front["front-end static files"]
+    gw -- local file --> front
+    
+    browser --> gw
+    gw -- HTTP --> editoast
+    editoast -- HTTP --> core
+```
+
+External requests are received by the gateway. If the path asked starts with `/api` it will be forwarded using HTTP to editoast, otherwise it will serve a file with the asked path. Editoast reach the core using HTTP if required.
+
+The gateway is not only a reverse proxy with the front-end bundle included, it also provides all the authentication mechanisms: using OIDC or tokens.

--- a/content/docs/explanation/containers-architecture/_index.fr.md
+++ b/content/docs/explanation/containers-architecture/_index.fr.md
@@ -1,0 +1,30 @@
+---
+title: "Architecture des conteneurs"
+linkTitle: "Architecture des conteneurs"
+weight: 10
+description: "Comment les conteneurs fonctionnent ensemble et comment ils sont construits"
+---
+
+Il y a 3 principaux conteneurs déployés dans une configuration OSRD standard :
+ - **Gateway** _(inclut le frontend)_ : Sert le front-end, gère l'authentification et proxy les requêtes vers le backend.
+ - **Editoast** : Agit comme le backend qui interagit avec le front-end.
+ - **Core** : Gère les calculs et la logique métier, appelé par Editoast.
+
+## Déploiement standard
+
+Le déploiement standard peut être représenté par le diagramme suivant.
+
+```mermaid
+flowchart TD
+    gw["gateway"]
+    front["fichiers statiques front-end"]
+    gw -- fichier local --> front
+    
+    navigateur --> gw
+    gw -- HTTP --> editoast
+    editoast -- HTTP --> core
+```
+
+Les requêtes externes sont reçues par le gateway. Si le chemin demandé commence par `/api`, il sera transféré en utilisant HTTP vers editoast, sinon il servira un fichier avec le chemin demandé. Editoast atteint le core en utilisant HTTP si nécessaire.
+
+Le gateway n'est pas seulement un proxy inverse avec le bundle front-end inclus, il fournit également tous les mécanismes d'authentification : utilisant OIDC ou des tokens.

--- a/content/docs/guides/deploy/_index.en.md
+++ b/content/docs/guides/deploy/_index.en.md
@@ -1,0 +1,15 @@
+---
+title: "Deploy OSRD"
+linkTitle: "Deploy OSRD"
+weight: 10
+description: Learn how to deploy OSRD in various environments
+---
+
+First of all, we recommend learning about the [containers architecture of OSRD]({{< ref "/docs/explanation/containers-architecture" >}}).
+
+We will cover how to deploy OSRD within the following setups:
+
+ - [Using docker compose]({{< ref "/docs/guides/deploy/docker-compose" >}}) on a single node.
+ - [Using helm]({{< ref "/docs/guides/deploy/docker-compose" >}}) on a kubernetes cluster.
+
+It is also possible to deploy each service of OSRD manually on a system, but we will not cover this topic within this guide.

--- a/content/docs/guides/deploy/_index.fr.md
+++ b/content/docs/guides/deploy/_index.fr.md
@@ -1,0 +1,15 @@
+---
+title: "Déployer OSRD"
+linkTitle: "Déployer OSRD"
+weight: 10
+description: Apprenez à déployer OSRD dans différents environnements
+---
+
+Tout d'abord, nous recommandons de se familiariser sur [l'architecture des conteneurs d'OSRD]({{< ref "/docs/explanation/containers-architecture" >}}).
+
+Nous allons couvrir comment déployer OSRD dans les configurations suivantes :
+
+- [Utiliser docker compose]({{< ref "/docs/guides/deploy/docker-compose" >}}) sur un seul nœud.
+- [Utiliser helm]({{< ref "/docs/guides/deploy/docker-compose" >}}) sur un cluster kubernetes.
+
+Il est également possible de déployer manuellement chaque service d'OSRD sur un système, mais nous ne couvrirons pas ce sujet dans ce guide.

--- a/content/docs/guides/deploy/docker-compose/_index.en.md
+++ b/content/docs/guides/deploy/docker-compose/_index.en.md
@@ -1,0 +1,56 @@
+---
+title: "Docker Compose"
+linkTitle: "Docker Compose"
+weight: 10
+description: Using docker compose for single node deployment
+---
+
+The OSRD project includes a `docker-compose.yml` file designed to facilitate the deployment of a fully functional OSRD environment. Primarily intended for development purposes, this Docker Compose configuration can also be adapted for quick, single-node deployments.
+
+## Prerequisites
+
+Before proceeding with the deployment, ensure that you have the following installed:
+- Docker
+- Docker Compose
+
+## Configuration Overview
+
+The `docker-compose.yml` file defines the following services:
+
+1. **PostgreSQL**: A PostgreSQL database with PostGIS extension. 
+2. **Redis**: A Redis server for caching.
+3. **Core**: The core OSRD service.
+4. **Front**: The front-end service for OSRD.
+5. **Editoast**: A OSRD service responsible for various editorial functions.
+6. **Gateway**: Serves as the gateway for the OSRD services.
+7. **Wait-Healthy**: A utility service to ensure all services are healthy before proceeding.
+
+Each service is configured with health checks, volume mounts and necessary environment variables.
+
+## Deployment Steps
+
+1. **Clone the Repository**: First, clone the OSRD repository to your local machine.
+2. **Environment Variables** (optional): Set necessary environment variables if you need to adjust some configurations.
+3. **Build and Run**: Navigate to the directory containing `docker-compose.yml` and run:
+
+```bash
+docker-compose up --build
+```
+
+This command builds the images and starts the services defined in the Docker Compose file.
+
+## Accessing Services
+
+While all HTTP service are used through the gateway (`http://localhost:4000`), you can access directly each service using their exposed ports:
+
+- **PostgreSQL**: Accessible on `localhost:5432`.
+- **Redis**: Accessible on `localhost:6379`.
+- **Core Service**: Accessible on `localhost:8080`.
+- **Front-End**: Accessible on `localhost:3000`.
+- **Editoast**: Accessible on `localhost:8090`.
+
+## Notes and Considerations
+
+- This setup is designed for development and quick deployments. For production environments, additional considerations for security, scalability and reliability should be addressed.
+- Ensure that the `POSTGRES_PASSWORD` and other sensitive credentials are securely managed, especially in production deployments.
+

--- a/content/docs/guides/deploy/docker-compose/_index.fr.md
+++ b/content/docs/guides/deploy/docker-compose/_index.fr.md
@@ -1,0 +1,57 @@
+---
+title: "Docker Compose"
+linkTitle: "Docker Compose"
+weight: 10
+description: Utiliser docker compose pour un déploiement sur un seul nœud
+---
+
+Le projet OSRD inclut un fichier docker-compose.yml conçu pour faciliter le déploiement d'un environnement OSRD pleinement fonctionnel. Initialement destiné à des fins de développement, ce Docker Compose peut également être adapté pour des déploiements rapides sur un seul nœud.
+
+## Prérequis
+
+Avant de procéder au déploiement, assurez-vous que vous avez installé :
+
+- Docker
+- Docker Compose
+
+## Vue d'ensemble de la configuration
+
+Le fichier `docker-compose.yml` définit les services suivants :
+
+1. **PostgreSQL** : Une base de données PostgreSQL avec l'extension PostGIS.
+2. **Redis** : Un serveur Redis pour le cache.
+3. **Core** : Le service central OSRD.
+4. **Front** : Le service front-end pour OSRD.
+5. **Editoast** : Un service OSRD responsable de diverses fonctions d'édition.
+6. **Gateway** : Sert de passerelle pour les services OSRD.
+7. **Wait-Healthy** : Un service utilitaire pour s'assurer que tous les services sont sains avant de procéder.
+
+Chaque service est configuré avec des contrôles de santé, des montages de volumes et les variables d'environnement nécessaires.
+
+## Étapes du déploiement
+
+1. **Cloner le dépôt** : Tout d'abord, clonez le dépôt OSRD sur votre machine locale.
+2. **Variables d'environnement** (facultatif) : Définissez les variables d'environnement nécessaires si vous devez ajuster certaines configurations.
+3. **Construire et exécuter** : Naviguez vers le répertoire contenant `docker-compose.yml` et exécutez :
+
+```bash
+docker-compose up --build
+```
+
+Cette commande construit les images et démarre les services définis dans le fichier Docker Compose.
+
+## Accès aux services
+
+Bien que tous les services HTTP soient utilisés via la passerelle (`http://localhost:4000`), vous pouvez accéder directement à chaque service en utilisant leurs ports exposés :
+
+- **PostgreSQL** : Accessible sur `localhost:5432`.
+- **Redis** : Accessible sur `localhost:6379`.
+- **Service Core** : Accessible sur `localhost:8080`.
+- **Front-End** : Accessible sur `localhost:3000`.
+- **Editoast** : Accessible sur `localhost:8090`.
+
+## Notes et considérations
+
+- Cette configuration est conçue pour le développement et les déploiements rapides. Pour les environnements de production, des considérations supplémentaires en matière de sécurité, de scalabilité et de fiabilité doivent être abordées.
+- Assurez-vous que le `POSTGRES_PASSWORD` et d'autres identifiants sensibles sont gérés en toute sécurité, en particulier dans les déploiements de production.
+

--- a/content/docs/guides/deploy/kubernetes/_index.en.md
+++ b/content/docs/guides/deploy/kubernetes/_index.en.md
@@ -1,0 +1,88 @@
+---
+title: "Kubernetes with Helm"
+linkTitle: "Kubernetes with Helm"
+weight: 10
+description: Using Helm for Kubernetes deployments
+---
+
+The OSRD project's Helm Chart provides a flexible and efficient way to deploy OSRD services in a Kubernetes environment. This document outlines the configuration options available in the Helm Chart, focusing on each service component.
+
+## Prerequisites
+
+Before proceeding with the deployment, ensure that you have the following installed:
+- A Kubernetes cluster up and running
+- A PostgreSQL database with PostGIS
+- A Redis server (used for caching)
+
+## The tileserver
+
+Tileserver is the component responsible for generating vector map tiles. It is recommended to separate it from standard Editoast while running a production setup since Editoast cannot be scaled horizontally (it is stateful).
+
+You can visualize the recommended deployment here:
+
+```mermaid
+flowchart TD
+    gw["gateway"]
+    front["front-end static files"]
+    gw -- local file --> front
+    
+    browser --> gw
+    gw -- HTTP --> editoast
+    gw -- HTTP --> tileserver-1
+    gw -- HTTP --> tileserver-2
+    gw -- HTTP --> tileserver-n...
+    editoast -- HTTP --> core
+```
+
+The Helm chart leverages Kubernete's [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) in order to spawn as much tileserver as required for the current workload.
+
+## Chart Values Overview
+
+The Helm Chart is configurable through the following values:
+
+### Core Service
+
+- `core`: Configuration for the core OSRD service.
+  - `internalUrl`: Internal URL for service communication.
+  - `image`: Docker image to use.
+  - `pullPolicy`: Image pull policy.
+  - `replicaCount`: Number of replicas.
+  - `service`: Service type and port configuration.
+  - `resources`, `env`, `annotations`, `labels`, `nodeSelector`, `tolerations`, `affinity`: Various Kubernetes deployment options.
+
+### Editoast Service
+
+- `editoast`: Configuration for the Editoast service.
+  - Includes similar options as `core` for Kubernetes deployment.
+  - `init`: Initialization configuration.
+
+### Tile Server
+
+- `tileServer`: Specialized Editoast service that serves only vector map tiles.
+  - `enabled`: Set to `true` to enable tile server functionality.
+  - `image`: Docker image to use (typically the same as Editoast).
+  - `replicaCount`: Number of replicas, allowing for horizontal scaling.
+  - `hpa`: Horizontal Pod Autoscaler configuration.
+  - Other standard Kubernetes deployment options.
+
+### Gateway
+
+- `gateway`: Configuration for the OSRD gateway.
+  - Includes service, ingress, and other Kubernetes deployment options.
+  - `config`: Specific configurations for authentication and trusted proxies.
+
+## Deployment
+
+The chart is available at ghcr OCI repository. You can find 2 Helm charts: 
+ - [Stable charts](https://github.com/osrd-project/osrd-chart/pkgs/container/charts%2Fosrd): `oci://ghcr.io/osrd-project/charts/osrd`
+ - [Dev charts](https://github.com/osrd-project/osrd-chart/pkgs/container/charts%2Fosrd-dev): `oci://ghcr.io/osrd-project/charts/osrd-dev`
+
+To deploy the OSRD services using this Helm Chart:
+
+1. **Configure Values**: Adjust the values in the Helm Chart to suit your deployment needs.
+2. **Install Chart**: Use Helm to install the chart into your Kubernetes cluster.
+
+   ```bash
+   helm install osrd oci://ghcr.io/osrd-project/charts/osrd -f values.yml
+   ```
+

--- a/content/docs/guides/deploy/kubernetes/_index.fr.md
+++ b/content/docs/guides/deploy/kubernetes/_index.fr.md
@@ -1,0 +1,88 @@
+---
+title: "Kubernetes avec Helm"
+linkTitle: "Kubernetes avec Helm"
+weight: 10
+description: Utilisation de Helm pour les déploiements Kubernetes
+---
+
+La Helm Chart du projet OSRD fournit une solution pour déployer les services OSRD dans un environnement Kubernetes de manière standardisée. Ce document décrit les options de configuration disponibles dans le Helm Chart.
+
+## Prérequis
+
+Avant de procéder au déploiement, assurez-vous que vous avez installé :
+
+- Un cluster Kubernetes opérationnel
+- Une base de données PostgreSQL avec PostGIS
+- Un serveur Redis (utilisé pour le cache)
+
+## Le serveur de tuiles
+
+Le serveur de tuiles est le composant responsable de la génération des tuiles cartographiques vectorielles. Il est recommandé de le séparer du Editoast standard lors de l'exécution d'une configuration de production, car Editoast ne peut pas être mis à l'échelle horizontalement (il est stateful).
+
+Vous pouvez visualiser le déploiement recommandé ici :
+
+```mermaid
+flowchart TD
+    gw["gateway"]
+    front["fichier statiques front-end"]
+    gw -- fichier local --> front
+    
+    navigateur --> gw
+    gw -- HTTP --> editoast
+    gw -- HTTP --> tileserver-1
+    gw -- HTTP --> tileserver-2
+    gw -- HTTP --> tileserver-n...
+    editoast -- HTTP --> core
+```
+
+Le Helm Chart utilise le[HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) de Kubernetes pour lancer autant de serveurs de tuiles que nécessaire en fonction de la charge de travail.
+
+## Configuration de la Helm Chart (values)
+
+Le Helm Chart est configurable à travers les valeurs suivantes :
+
+### Service Core
+
+- `core` : Configuration pour le service central OSRD.
+  - `internalUrl` : URL interne pour la communication entre services.
+  - `image` : Image Docker à utiliser.
+  - `pullPolicy` : Politique de récupération de l'image.
+  - `replicaCount` : Nombre de réplicas.
+  - `service` : Type de service et configuration des ports.
+  - `resources`, `env`, `annotations`, `labels`, `nodeSelector`, `tolerations`, `affinity` : Diverses options de déploiement Kubernetes.
+
+### Service Editoast
+
+- `editoast` : Configuration pour le service Editoast.
+  - Comprend des options similaires à `core` pour le déploiement Kubernetes.
+  - `init` : Configuration d'initialisation.
+
+### Serveur de tuiles
+
+- `tileServer` : Service Editoast spécialisé qui sert uniquement des tuiles cartographiques vectorielles.
+  - `enabled` : Définir sur `true` pour activer la fonctionnalité de serveur de tuiles.
+  - `image` : Image Docker à utiliser (généralement la même que Editoast).
+  - `replicaCount` : Nombre de réplicas, permettant la mise à l'échelle horizontale.
+  - `hpa` : Configuration de l'Horizontal Pod Autoscaler.
+  - Autres options standard de déploiement Kubernetes.
+
+### Gateway
+
+- `gateway` : Configuration pour le gateway OSRD.
+  - Comprend des options de service, d'ingress et d'autres options de déploiement Kubernetes.
+  - `config` : Configurations spécifiques pour l'authentification et les proxys de confiance.
+
+## Déploiement
+
+Le chart est disponible dans le dépôt OCI ghcr. Vous pouvez trouver 2 versions de la chart :
+ - [Charts stables](https://github.com/osrd-project/osrd-chart/pkgs/container/charts%2Fosrd) : `oci://ghcr.io/osrd-project/charts/osrd`
+ - [Charts de développement](https://github.com/osrd-project/osrd-chart/pkgs/container/charts%2Fosrd-dev) : `oci://ghcr.io/osrd-project/charts/osrd-dev`
+
+Pour déployer les services OSRD en utilisant Helm :
+
+1. **Configurer les valeurs** : Ajustez les valeurs selon vos besoins de déploiement.
+2. **Installer le Chart** : Utilisez la commande `helm install` pour installer la chart dans votre cluster Kubernetes.
+
+   ```bash
+   helm install osrd oci://ghcr.io/osrd-project/charts/osrd -f values.yml
+   ```


### PR DESCRIPTION
This modification add guides that cover deployments

- [X] Describe container architecture
  - [X] English
  - [X] French
- [X] Helm depoloyments
  - [X] English
  - [X] French
- [X] Docker compose deployments
  - [X] English
  - [X] French