### PR TITLE
ci: check commit titles

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,0 +1,41 @@
+name: Check code quality
+
+on:
+  pull_request:
+
+jobs:
+  check_commits:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch all history for all branches and tags
+
+    - name: Check commit names
+      run: |
+        # We don't have a base ref to check against if we aren't in a
+        # pull_request workflow.
+        BASE=${{ github.base_ref }}
+        if [[ -z "$BASE" ]]; then
+          exit 0
+        fi
+
+        commit_titles() {
+          git log --format=%s origin/"$BASE"..HEAD --skip=1
+        }
+
+        if commit_titles | grep -i '^fixup'; then
+          echo "Found a fixup commit"
+          exit 1
+        fi
+
+        # Check that commit contains ':' (and no autosquashable commit using '!')
+        if commit_titles | grep -E -v '^([-.a-z]+[,:] )*[-.a-z]+: [a-z][a-z0-9 _.,+-`/]*$'; then
+          echo "All commit messages must use the following format:"
+          echo "  external-doc: add fancy schema"
+          echo
+          echo "When a commit changes multiple modules, separate module names with ', ':"
+          echo "  blog, doc: improve display"
+          exit 1
+        fi


### PR DESCRIPTION
This will enforce common format for titles.
This will also avoid `fixup!` `squash!` and `amend!` (autosquash) commits.

Inspired from osrd-project/osrd#6484