### PR TITLE
doc, ci: precise commit style

### DIFF
--- a/.github/scripts/check-commit-titles.sh
+++ b/.github/scripts/check-commit-titles.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+# This script reads newline separated commit titles from stdin
+# output an error message when titles are deemed invalid,
+# and exits accordingly
+
+if [ -z "$NOCOLOR" ]; then
+    RED=$(tput setaf 1 2>/dev/null)
+    YELLOW=$(tput setaf 3 2>/dev/null)
+    BLUE=$(tput setaf 4 2>/dev/null)
+    RESET=$(tput sgr0 2>/dev/null)
+fi
+
+
+checks='check_fixup check_printable_ascii check_forbidden_chars check_structure'
+
+
+check_fixup() {
+    if grep -q -i '^fixup'; then
+        echo 'Found a fixup commit'
+    fi
+}
+
+check_printable_ascii() {
+    if grep -q -P -v '^[\x20-\x7F]*$'; then
+        echo 'Commit titles must be printable ascii only'
+    fi
+}
+
+check_forbidden_chars() {
+    if grep -q -P -v '^[^#]*$'; then
+        echo 'Forbidden character found: #'
+    fi
+}
+
+check_structure() {
+    if grep -q -E -v '^([-_.a-z]+[,:] )*[-_.a-z]+: [a-z](:[^ ]|[^:])*$'; then
+        echo 'Invalid commit title structure'
+    fi
+}
+
+
+# read commit titles from stdin
+check_failed=
+while IFS= read -r commit_title; do
+    # ensure failure messages are newline separated
+    if [ -n "$commit_check_failed" ]; then
+        printf '\n'
+    fi
+
+    # apply checks
+    commit_check_failed=
+    for check in $checks; do
+        check_error=$(printf '%s\n' "$commit_title" | "$check")
+        if [ -z "$check_error" ]; then
+            continue
+        fi
+
+        # if it's the first error for this commit, print the error header
+        if [ -z "$commit_check_failed" ]; then
+            printf '%sinvalid commit title:%s ' "$RED" "$RESET"
+            printf '%s%s%s\n' "$BLUE" "$commit_title" "$RESET"
+        fi
+
+        printf '   %s- %s%s\n' "$RED" "$check_error" "$RESET"
+        commit_check_failed=y
+        check_failed=y
+    done
+done
+
+if [ -z "$check_failed" ]; then
+    exit 0
+fi
+
+cat<<EOF
+
+All commit messages must use the following format:
+  ${BLUE}core: add fancy margin support${RESET}
+
+When a commit changes multiple modules, separate module names with ", ":
+  ${BLUE}core, editoast: fix curve simplification${RESET}
+
+If the involved module are bound by a hierarchical relationship, use ": " instead:
+  ${BLUE}core: signaling: support distant signals${RESET}
+
+The following characters are forbidden:
+  - anything outside of the ascii range
+  - non-printable ascii (which includes tabs)
+  - #
+
+Commit title structure has to be as follows:
+  - one or more module names ([-_.a-z]+), separated by comma or colon, terminated by ": "
+  - the actual title, starting with a lowercase letter and not containing ": "
+EOF
+exit 1

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -25,17 +25,4 @@ jobs:
           git log --format=%s origin/"$BASE"..HEAD --skip=1
         }
 
-        if commit_titles | grep -i '^fixup'; then
-          echo "Found a fixup commit"
-          exit 1
-        fi
-
-        # Check that commit contains ':' (and no autosquashable commit using '!')
-        if commit_titles | grep -E -v '^([-.a-z]+[,:] )*[-.a-z]+: [a-z][a-z0-9 _.,+-`/]*$'; then
-          echo "All commit messages must use the following format:"
-          echo "  external-doc: add fancy schema"
-          echo
-          echo "When a commit changes multiple modules, separate module names with ', ':"
-          echo "  blog, doc: improve display"
-          exit 1
-        fi
+        commit_titles | TERM=xterm-color .github/scripts/check-commit-titles.sh

--- a/content/docs/guides/contribute/contribute-code/commit-style.en.md
+++ b/content/docs/guides/contribute/contribute-code/commit-style.en.md
@@ -8,15 +8,35 @@ description: "A few advises and rules about commit messages"
 The overall format for git commits is as follows:
 
 ```
-component: imperative description of the change
+component1, component2: imperative description of the change
 
-Detailed description of the change and what motivates it,
+Detailed or technical description of the change and what motivates it,
 if it is not entirely obvious from the title.
 ```
 
-- **the commit message, just like the code, must be in english**
-- all lowercase
+- **the commit message, just like the code, must be in english** (only ASCII characters for the title)
 - there can be multiple components separated by `:` in case of hierarchical relationships, with `,` otherwise
-- the body of the commit should probably contain a detailed description of the change
+- components are lower-case, using `-`, `_` or `.` if necessary
+- the imperative description of the change begins with a lower-case verb
+- the title must not contain any link (`#` is forbidden)
+
+Ideally:
+
+- the title should be self-explanatory: no need to read anything else to understand it
+- the commit title is all lower-case
+- the title is clear to a reader not familiar with the code
+- the body of the commit contains a detailled description of the change
+
+{{% alert title="" color="info"%}}
+An automated check is performed to enforce as much as possible this formating.
+{{% /alert %}}
+
+### Counter-examples of commit titles
+
+- `component: update ./some/file.ext`: specify the update itself rather than the file, the files
+  are technical elements welcome in the _body_ of the commit
+- `component: fix #42`: specify the problem fixed in the title, links (to issue, etc.) are very
+  welcome in commit's _body_
+- `wip`: describe the work (and finish it)
 
 *[Continue towards sharing your changes ‣]({{< ref "share-changes">}})*

--- a/content/docs/guides/contribute/contribute-code/commit-style.fr.md
+++ b/content/docs/guides/contribute/contribute-code/commit-style.fr.md
@@ -8,15 +8,34 @@ description: "Quelques bonnes pratiques et règles pour les messages de commits"
 Le format général des commits est le suivant :
 
 ```
-composant: description du changement à l'impératif
+composant1, composant2: description du changement à l'impératif
 
-Description détaillée du contenu et de la motivation du changement,
-si le titre n'est pas complètement évident.
+Description détaillée ou technique du contenu et de la motivation du
+changement, si le titre n'est pas complètement évident.
 ```
 
-- **le message comme le code doit être en anglais**
-- tout en minuscule
+- **le message comme le code doit être en anglais** (seulement des caractères ASCII pour le titre)
 - il peut y avoir plusieurs composants, séparés par des `:` quand il y a une relation hiérarchique, ou des `,` sinon
-- dans l'idéal, le corps du commit contient une description du changement.
+- les composants sont en minuscule, avec éventuellement `-`, `_` ou `.`
+- la description du changement à l'impératif commence par un verbe en minuscule
+- le titre ne doit pas comporter de lien (`#` est interdit)
+
+Idéalement :
+- le titre doit être autonome : pas besoin de lire autre chose pour le comprendre
+- le titre du commit est entièrement en minuscule
+- le titre est clair pour une personne étrangère au code
+- le corps du commit contient une description du changement
+
+{{% alert title="" color="info"%}}
+Une vérification automatique est effectuée pour vérifier autant que possible ce formatage.
+{{% /alert %}}
+
+### Contre-exemples de titres de commit
+
+- `component: update ./some/file.ext` : préciser la mise à jour en question plutôt que le fichier,
+  les fichiers sont des éléments techniques bienvenus dans le _corps_ du commit
+- `component: fix #42` : préciser le problème corrigé, les liens (vers l'issue, etc.) sont
+  encouragés dans le _corps_ du commit
+- `wip` : décrire le travail (et le finir)
 
 *[Continuer vers le partage des changements ‣]({{< ref "share-changes">}})*


### PR DESCRIPTION
also port last check of commit after ~https://github.com/osrd-project/osrd/pull/6557~ https://github.com/osrd-project/osrd/pull/6580

TODO:
- [x] sync regex of this repository once `osrd` is merged
- [x] wait for merge of #154 and rebase + autosquash