### PR TITLE
doc: move dependencies bump batching in general principles

### DIFF
--- a/content/docs/guides/contribute/contribute-code/general-principles.en.md
+++ b/content/docs/guides/contribute/contribute-code/general-principles.en.md
@@ -13,6 +13,8 @@ description: "Please read this first!"
 - Avoid non well-known abbreviations.
 - **Control and consistency over 3rd party code reuse**: Only add a dependency if it is absolutely necessary.
 - Every dependency we add decreases our autonomy and consistency.
+- We try to keep PRs bumping dependencies to a low number each week in each component, so grouping
+dependency bumps in a batch PR is a valid option (see component's `README.md`).
 - **Don't reinvent every wheel**: as a counter to the previous point, don't reinvent everything at all costs.
 - If there is a dependency in the ecosystem that is the "de facto" standard, we should heavily consider using it.
 - More code general recommendations in main repository [CONTRIBUTING.md](https://github.com/osrd-project/osrd/blob/dev/CONTRIBUTING.md).

--- a/content/docs/guides/contribute/contribute-code/general-principles.fr.md
+++ b/content/docs/guides/contribute/contribute-code/general-principles.fr.md
@@ -13,6 +13,9 @@ description: "À lire en premier !"
 - Évitez les abréviations peu connues.
 - **Contrôle et cohérence de la réutilisation du code de tiers** : une dépendance est ajoutée seulement si elle est absolument nécessaire.
 - Chaque dépendance ajoutée diminue notre autonomie et notre cohérence.
+- Nous essayons de limiter à un petit nombre les PRs de mise à jour des dépendances chaque semaine
+dans chaque composant, donc regrouper les montées de version dans une même PR est une bonne option
+(reportez-vous au `README.md` de chaque composant).
 - **Ne pas réinventer la roue** : en opposition au point précédent, ne réinventez pas tout à tout prix.
 - S'il existe une dépendance dans l'écosystème qui est le standard « de facto », nous devrions fortement envisager de l'utiliser.
 - Plus de code et de recommandations générales dans le dépôt principal [CONTRIBUTING.md](https://github.com/osrd-project/osrd/blob/dev/CONTRIBUTING.md).

--- a/content/docs/guides/contribute/license-and-set-up.en.md
+++ b/content/docs/guides/contribute/license-and-set-up.en.md
@@ -38,18 +38,3 @@ Thanks to `docker`, one can easily compile, configure, and run all services afte
 [^docker-desktop]: Under Windows/[WSL](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-containers), [Docker Desktop](https://www.docker.com/products/docker-desktop/) is recommended
 
 *[Continue towards code contribution ‣]({{< ref "contribute-code">}})*
-
-#### `editoast` specific: batch dependency updates
-
-We use dependabot on the project to signal when dependencies are outdated. We do not use dependabot to automatically update dependencies, as we want to merge all updates at once and review the changes.
-
-Here is the process to update dependencies:
-
-1. Change the versions.
-    * *If you're using VSCode* you can install the [`serayuzgur.crates`](https://marketplace.visualstudio.com/items?itemName=serayuzgur.crates) extension and run the "update all dependencies" command.  
-    Make sure that the new version chosen is stable, and that loose constraints are not overwritten in your commit.
-    * *If you're not*, you can go check the versions used by dependabot in [its PRs](https://github.com/osrd-project/osrd/pulls?q=is%3Aopen+label%3Aarea%3Aeditoast+label%3Adependencies) and update the versions manually.
-2. Run `cargo update` to update the Cargo.lock file (even sub-dependencies).
-3. Check that all [dependabot editoast PRs](https://github.com/osrd-project/osrd/pulls?q=is%3Aopen+label%3Aarea%3Aeditoast+label%3Adependencies) are included in your update.
-4. Adapt the code to the new versions, if needed.
-5. Create a PR with your changes, and link all dependabot PRs in the description.

--- a/content/docs/guides/contribute/license-and-set-up.fr.md
+++ b/content/docs/guides/contribute/license-and-set-up.fr.md
@@ -38,19 +38,3 @@ Grâce à `docker`, on peut facilement compiler, configurer, et lancer les diff�
 [^docker-desktop]: Sous Windows/[WSL](https://learn.microsoft.com/fr-fr/windows/wsl/tutorials/wsl-containers), [Docker Desktop](https://www.docker.com/products/docker-desktop/) est recommandé
 
 *[Continuer vers la contribution au code ‣]({{< ref "contribute-code">}})*
-
-#### Spécifique `editoast` : mise à jour groupée des dépendances
-
-Nous utilisons dependabot sur le projet pour signaler quand les dépendances sont obsolètes. Nous ne nous en servons pas pour mettre à jour automatiquement les dépendances, pour intégrer toutes les mises à jour en une seule fois et relire les modifications.
-
-Pour mettre à jour les dépendances :
-
-1. Changez les versions.
-    * *Si vous utilisez VSCode* vous pouvez installer l'extension [`serayuzgur.crates`](https://marketplace.visualstudio.com/items?itemName=serayuzgur.crates) et exécuter la commande "update all dependencies".  
-    Cela mettra à jour toutes les dépendances vers leur dernière version, et écrasera les contraintes de version trop larges.  
-    Assurez-vous que la nouvelle version choisie est stable, et que les contraintes volontairement larges ne sont pas écrasées par votre commit.
-    * *Sinon* vous pouvez vérifier les versions utilisées par dependabot dans [ses PRs](https://github.com/osrd-project/osrd/pulls?q=is%3Aopen+label%3Aarea%3Aeditoast+label%3Adependencies) et mettre à jour les versions manuellement.
-2. Exécutez `cargo update` pour mettre à jour le fichier Cargo.lock (y compris les sous-dépendances).
-3. Vérifiez que toutes les [PRs dependabot editoast](https://github.com/osrd-project/osrd/pulls?q=is%3Aopen+label%3Aarea%3Aeditoast+label%3Adependencies) sont inclus dans votre commit.
-4. Adaptez le code aux nouvelles versions, si nécessaire.
-5. Créez une PR avec vos modifications, et reliez-y tous les PRs dependabot en description.


### PR DESCRIPTION
Details for editoast are moved close to the code, in `osrd/editoast/README.md` (see https://github.com/osrd-project/osrd/pull/6762).

Follow-up on https://github.com/osrd-project/osrd-website/pull/154#pullrequestreview-1865252374